### PR TITLE
Fix difficulty moving to the right with slow crank movement

### DIFF
--- a/source/classes/class-game.lua
+++ b/source/classes/class-game.lua
@@ -267,6 +267,7 @@ function Game:dropBall()
 
 	self.didCombo = false
 
+	self.playerPosition.x = math.floor(self.playerPosition.x + 0.5)
 	Ball(self.playerPosition, self.currentBall):add()
 
 	self.currentBall = self.nextBall
@@ -284,8 +285,6 @@ function Game:fixPlayerBounds()
 	if self.playerPosition.x < 160 + (self.currentBall.radius) then
 		self.playerPosition.x = 160 + (self.currentBall.radius)
 	end
-
-	self.playerPosition.x = math.floor(self.playerPosition.x)
 end
 
 function Game:gameOver(restart)
@@ -343,14 +342,15 @@ end
 
 function Game:draw()
 	-- Draw the current ball at the player position.
+	local roundedPlayerX = math.floor(self.playerPosition.x + 0.5)
 	Ball:draw(self.currentBall.radius, self.currentBall.level):drawCentered(
-		self.playerPosition.x,
+		roundedPlayerX,
 		self.positionTimer.value
 	)
 
 	gfx.setColor(gfx.kColorWhite)
 	gfx.setDitherPattern(0.8, gfx.image.kDitherTypeHorizontalLine)
-	gfx.drawLine(self.playerPosition.x, self.killZone, self.playerPosition.x, 240)
+	gfx.drawLine(roundedPlayerX, self.killZone, roundedPlayerX, 240)
 	gfx.setDitherPattern(0)
 end
 


### PR DESCRIPTION
I don't know if you accept pull requests, but in case you do, here is one that fixes an issue that has been bugging me: When moving the crank slowly, the planet hardly moves to the right (whereas moving to the left works as expected), which makes it hard to aim precisely.

The reason, as I immediately suspected, is that the position is rounded to whole numbers immediately after adding the crank increment, which eats up small increments. Instead, round only before dropping a ball, so that small increments can add up while moving. Also round to nearest instead of down to avoid bias toward the left. (I didn't check whether balls even need to be at integer positions, but I'm leaving that the way it was.)