### PR TITLE
Fix failure to gray out planets at game over

### DIFF
--- a/source/classes/class-game.lua
+++ b/source/classes/class-game.lua
@@ -293,7 +293,7 @@ function Game:gameOver(restart)
 	gfx.sprite.performOnAllSprites(function(sprite)
 		sprite:setUpdatesEnabled(false)
 
-		if nil == sprite.killer or not sprite.killer then
+		if sprite ~= self.guiImage and not sprite.killer then
 			sprite:setStencilPattern({ 0xff, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff, 0x00 })
 		end
 	end)


### PR DESCRIPTION
Here’s another fix for something that (for some reason I haven’t understood yet) appears to have gotten worse with 0.1.4: When the game is over, most planets are not drawn grayed out as the intention seems to have been, which also makes the “LOADING…” text hard to see:

Actual:
![gameover-before](https://github.com/tommusrhodus/Legally-Distinct--Planetary-Based--Suika-Game-Clone-for-Playdate/assets/234094/0f4933a3-3c66-4977-bb16-91e9eadb0b72)

Expected:
![gameover-after](https://github.com/tommusrhodus/Legally-Distinct--Planetary-Based--Suika-Game-Clone-for-Playdate/assets/234094/1f56ceb9-0b23-4a54-98fa-1e6bd956f2ad)

When the stencil was set on _all_ sprites including the GUI, whatever was in the frame buffer before stayed on the stenciled-out lines, which in most cases was the planets as they appeared before stenciling, rendering the stenciling ineffective. Probably the intention was that the dark background would show through, so we still need to draw that background in full.

Also, a separate check for nil is unnecessary since nil is falsy by itself.